### PR TITLE
Fix: anchor onHover bug in Firefox

### DIFF
--- a/src/common/navigation/component/Sidenav.styles.scss
+++ b/src/common/navigation/component/Sidenav.styles.scss
@@ -89,6 +89,10 @@
     color: $light;
 }
 
+.a, a:link {
+    color: $light;
+}
+
 .noHover{
     pointer-events: none;
 }


### PR DESCRIPTION
Noticed when opening the Sidenav in Firefox that hovering over the buttons causes the text to flash blue. Added code to account for the way Firefox separates the color of unclicked links. 